### PR TITLE
Change "'<" and "'>" to "v" and ".".

### DIFF
--- a/autoload/asterisk.vim
+++ b/autoload/asterisk.vim
@@ -86,7 +86,7 @@ function! s:convert_2_word_pattern_4_visual(pattern, config) abort
     if a:config.is_whole
         let head = matchstr(text, '^.')
         let is_head_multibyte = 1 < len(head)
-        let [l, col] = getpos("'<")[1 : 2]
+        let [l, col] = getpos("v")[1 : 2]
         let line = getline(l)
         let before = line[: col - 2]
         let outer = matchstr(before, '.$')
@@ -96,7 +96,7 @@ function! s:convert_2_word_pattern_4_visual(pattern, config) abort
         endif
         let tail = matchstr(text, '.$')
         let is_tail_multibyte = 1 < len(tail)
-        let [l, col] = getpos("'>")[1 : 2]
+        let [l, col] = getpos(".")[1 : 2]
         let col += len(tail) - 1
         let line = getline(l)
         let after = line[col :]


### PR DESCRIPTION
`'<` and `'>` are mark of the last selected visual area in the current buffer,
so, search pattern at the first time in the current buffer is different from pattern at the second time.
- first time
  
  ```
  vim ./plugin/asterisk.vim
  :map * <Plug>(asterisk-z*)
  /save_cpo
  zo
  fc
  v2l
  *
  ```
  - search pattern is `\V\<cpo\>`
- second time
  
  ```
  Fc
  v2l
  *
  ```
  - search pattern is `\Vcpo\>`
