### PR TITLE
add keep cursor pos functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Search selected text.
 ### 3. Use smartcase unlike default one
 Default behavior, which see ignorecase and not smartcase, is not intuitive.
 
+### 4. Keep cursor position across matches
+Keeping cursor position while itering over matches is handy or refactoring.
+Tips: ```nmap § .n``` will allow you to use asterisk as multiple cursors in a vim way
+
 Installation
 ------------
 
@@ -64,6 +68,11 @@ map *  <Plug>(asterisk-z*)
 map #  <Plug>(asterisk-z#)
 map g* <Plug>(asterisk-gz*)
 map g# <Plug>(asterisk-gz#)
+yy```
+
+To enable keepCursor feature:
+```vim
+let g:asterisk#keeppos = 1
 ```
 
 Special thanks

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Default behavior, which see ignorecase and not smartcase, is not intuitive.
 
 ### 4. Keep cursor position across matches
 Keeping cursor position while itering over matches is handy or refactoring.
+
 Tips: ```nmap § .n``` will allow you to use asterisk as multiple cursors in a vim way
 
 Installation
@@ -68,7 +69,7 @@ map *  <Plug>(asterisk-z*)
 map #  <Plug>(asterisk-z#)
 map g* <Plug>(asterisk-gz*)
 map g# <Plug>(asterisk-gz#)
-yy```
+```
 
 To enable keepCursor feature:
 ```vim

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Search selected text.
 Default behavior, which see ignorecase and not smartcase, is not intuitive.
 
 ### 4. Keep cursor position across matches
-Keeping cursor position while itering over matches is handy or refactoring.
+Keeping cursor position while itering over matches is handy for refactoring.
 
 Tips: ```nmap § .n``` will allow you to use asterisk as multiple cursors in a vim way
 

--- a/autoload/asterisk.vim
+++ b/autoload/asterisk.vim
@@ -161,8 +161,7 @@ endfunction
 
 " @return boolean
 function! s:is_head_of_cword(cword) abort
-    let c = col('.')
-    return a:cword is# getline(line('.'))[c - 1 : c + strlen(a:cword) - 2]
+    return 0 == get_pos_in_cword(a:cword)
 endfunction
 
 " Assume the current mode is middle of visual mode.

--- a/doc/asterisk.txt
+++ b/doc/asterisk.txt
@@ -85,6 +85,10 @@ USAGE							*asterisk-usage*
 	    - It works in visual mode in addition to |Normal| & |Visual|.
 	      Search selected text.
 	    - "z" prefixed mappings doesn't move the cursor.
+	    - You can keep cursor position while moving across matches
+		    By default this feature is disabeled but you can activate
+		    it by adding to your vimrc:
+			let g:asterisk#keeppos = 1
 
 	Example: Write following lines to your vimrc:
 >
@@ -122,6 +126,10 @@ CREDITS                                                    *asterisk-credits*
 
 ==============================================================================
 CHANGELOG						*asterisk-changelog*
+
+
+0.9.4	2015-02-05
+	- Add keepCursor option
 
 0.9.3	2014-12-10
 	- Fix multybite handling for visual-star feature.


### PR DESCRIPTION
It is transparent for the user, just prevent user from loosing the cursor position when moving across matches.
Realy usefull to apply same action on matches with ```.```.

Improved and simplify the stay part, prefix with ```0``` the search will keep cursor on first match.

I just have a doubt about history, can't figure out where the offser variable is set in Vim... maybe you have an idea ?

To stay consistent, ```is_head_of_cword()``` could use ```get_pos_in_cword``` but it is a detail.