### PR TITLE
Fix handling of <CR>

### DIFF
--- a/autoload/asterisk.vim
+++ b/autoload/asterisk.vim
@@ -170,6 +170,7 @@ function! s:convert_2_word_pattern_4_visual(pattern, config) abort
         endif
     endif
     let text = substitute(escape(text, '\' . type), "\n", '\\n', 'g')
+    let text = substitute(text, "\r", '\\r', 'g')
     return '\V' . pre . text . post
 endfunction
 

--- a/test/visual.vimspec
+++ b/test/visual.vimspec
@@ -11,6 +11,7 @@ Describe visual
         \   , '.* asterisk asterisk'
         \   , '".*" ".*" ''asterisk'' ''asterisk'''
         \   , '"''.*" "''.*" "aste"risk" "aste"risk"'
+        \   , "asterisk\r"
         \ ]
         call g:Add_lines(lines)
     End
@@ -117,6 +118,13 @@ Describe visual
             silent! execute 'normal' "\<C-v>ej*"
             Assert Equals(@/, '\V\<asterisk\nAsterisk\>')
         End
+    End
+
+    Context contains \r
+      It handles correctly
+        normal 8j$v*
+        Assert Equals(@/, '\V\r')
+      End
     End
 
 


### PR DESCRIPTION
When a selected text contains `<CR>` character(it is shown as `^M`), E114 error occurs.
This PR fix it.