### PR TITLE
Fix https://github.com/haya14busa/vim-asterisk/issues/34.

### DIFF
--- a/autoload/asterisk.vim
+++ b/autoload/asterisk.vim
@@ -84,6 +84,8 @@ function! asterisk#do(mode, config) abort
         \   (a:mode isnot# 'n' ? "\<Esc>" : '')
         \   . 'm`'
         \   . (config.direction is s:DIRECTION.forward ? '0' : '$')
+        " NOTE: Neovim doesn't stack pos to jumplist after "m`".
+        " https://github.com/haya14busa/vim-asterisk/issues/34
         if has('nvim')
             let aftermove = '``'
         else

--- a/autoload/asterisk.vim
+++ b/autoload/asterisk.vim
@@ -84,7 +84,11 @@ function! asterisk#do(mode, config) abort
         \   (a:mode isnot# 'n' ? "\<Esc>" : '')
         \   . 'm`'
         \   . (config.direction is s:DIRECTION.forward ? '0' : '$')
-        let aftermove = "\<C-o>"
+        if has('nvim')
+            let aftermove = '``'
+        else
+            let aftermove = "\<C-o>"
+        endif
         " NOTE: To avoid hit-enter prompt, it execute `restore` and `echo`
         " command separately. I can also implement one function and call it
         " once instead of separately, should I do this?

--- a/test/basic_asterisk.vimspec
+++ b/test/basic_asterisk.vimspec
@@ -14,7 +14,7 @@ Describe basic_asterisk
     End
 
     Before each
-        :1
+        call cursor([1, 1])
         normal! 2l
     End
 

--- a/test/keeppos.vimspec
+++ b/test/keeppos.vimspec
@@ -13,7 +13,7 @@ Describe basic_asterisk
   End
 
   Before each
-    :1
+    call cursor([1, 1])
     normal! 2l
   End
 

--- a/test/visual.vimspec
+++ b/test/visual.vimspec
@@ -17,7 +17,7 @@ Describe visual
     End
 
     Before each
-        :1
+        call cursor([1, 1])
         normal! 2l
         let @/ = ''
     End

--- a/test/zstar.vimspec
+++ b/test/zstar.vimspec
@@ -12,7 +12,7 @@ Describe zstar
     End
 
     Before each
-        :1
+        call cursor([1, 1])
         normal! 2l
         let @/ = ''
     End
@@ -49,7 +49,7 @@ Describe zstar
           call g:Add_lines(['NeoBundle "kannokanno/previm"'])
           let save = &selection
           for v in ['inclusive', 'old', 'exclusive']
-            :1
+            call cursor([1, 1])
             Assert Equals(g:Get_pos_char(), 'N')
             let &selection=v
             normal ve6ho*


### PR DESCRIPTION
This is simply fixes https://github.com/haya14busa/vim-asterisk/issues/34 changing `<C-o>` to ``` `` ``` .
I tried to make tests that fails with old version but not succeeded yet.
This is my try.

```vim
        It my-test
            set hidden
            let g:asterisk#keeppos = 1
            new aaa
            new bbb
            exe "normal! iabc\<ESC>"
            let bufnr = bufnr('%')
            Assert Equals(g:Get_pos_char(), 'c')
            normal z*
            Assert Equals(bufnr, bufnr('%'))
            Assert Equals(g:Get_pos_char(), 'c')
            bw! aaa
            bw! bbb
        End
```
