### PR TITLE
consider '/' char when escaping

### DIFF
--- a/autoload/asterisk.vim
+++ b/autoload/asterisk.vim
@@ -351,7 +351,7 @@ endfunction
 
 " taken from :h Vital.Prelude.escape_pattern()
 function! s:escape_pattern(str) abort
-    return escape(a:str, '~"\.^$[]*')
+    return escape(a:str, '~"\.^$[]*/')
 endfunction
 
 " Restore 'cpoptions' {{{


### PR DESCRIPTION
In Clojure there are many keywords with the form `namespace/symbol`. `vim-asterisk` does not work properly if `g:asterisk#keeppos` is `1` and it is on such a keyword.

This fixes the issue by also escaping the `/` character.